### PR TITLE
Improve regular expressions

### DIFF
--- a/increment_decrement.py
+++ b/increment_decrement.py
@@ -67,13 +67,13 @@ class IncrementDecrementCommand(sublime_plugin.TextCommand):
                 if self.view.substr(region) in self._boolean_matches():
                     guess_type = 'bool'
                 # binary
-                elif re.match(r'0b.', self.view.substr(region)):
+                elif re.match(r'0b[01]', self.view.substr(region)):
                     guess_type = 'bin'
                 # hexadecimal
-                elif re.match(r'0x.', self.view.substr(region)):
+                elif re.match(r'0x[0-9a-fA-F]', self.view.substr(region)):
                     guess_type = 'hex'
                 # roman numeral
-                elif re.match(r'[IVXLC]+|[ivxlc]+', self.view.substr(region)):
+                elif re.match(r'([IVXLC]+|[ivxlc]+)$', self.view.substr(region)):
                     guess_type = 'roman'
                 else:
                     raise ValueError
@@ -83,15 +83,15 @@ class IncrementDecrementCommand(sublime_plugin.TextCommand):
             value = self.view.substr(region)
             if value in self._boolean_matches():
                 guess_type = 'bool'
-            elif re.match(r'[IVXLC]+|[ivxlc]+', self.view.substr(region)):
+            elif re.match(r'([IVXLC]+|[ivxlc]+)$', self.view.substr(region)):
                 guess_type = 'roman'
             elif re.match(r'[-]?\d+$', value):
                 guess_type = 'int'
-            elif re.match(r'[-]?\d+\.\d+$|\.\d+|\d+\.', value):
+            elif re.match(r'[-]?(\d+\.\d+|\.\d+|\d+\.)$', value):
                 guess_type = 'dec'
-            elif re.match(r'0b.', self.view.substr(region)):
+            elif re.match(r'0b[01]', self.view.substr(region)):
                 guess_type = 'bin'
-            elif re.match(r'0x.', self.view.substr(region)):
+            elif re.match(r'0x[0-9a-fA-F]', self.view.substr(region)):
                 guess_type = 'hex'
             else:
                 raise ValueError


### PR DESCRIPTION
Hello. I identified some improvements to the regex in this package.

Among the changes, there is a solution to issue #3, which was triggered by a partial match of a roman numeral on a selection. Notice how every input that caused the issue starts in a roman digit. The variable `region` was never updated to match the real range of `value`, and later it hanged in conversion. It seems that a full match is expected there and that's the fix.

Fixes #3